### PR TITLE
[18.0] Improve your v18 PR to migrate currency_rate_update

### DIFF
--- a/currency_rate_update/README.rst
+++ b/currency_rate_update/README.rst
@@ -31,13 +31,13 @@ Currency Rate Update
 This module provides base for building exchange rates providers and
 bundles following built-in providers:
 
-   - **European Central Bank** (ported by Grzegorz Grzelak -
-     OpenGLOBE.pl): reference rates are based on the regular daily query
-     procedure between central banks within and outside the European
-     System of Central Banks, which normally takes place at 2:15 p.m.
-     (14:15) ECB time. Source is in EUR, for more details see
-     `corresponding ECB
-     page <https://www.ecb.europa.eu/stats/policy_and_exchange_rates/euro_reference_exchange_rates/html/index.en.html>`__.
+   -  **European Central Bank** (ported by Grzegorz Grzelak -
+      OpenGLOBE.pl): reference rates are based on the regular daily
+      query procedure between central banks within and outside the
+      European System of Central Banks, which normally takes place at
+      2:15 p.m. (14:15) ECB time. Source is in EUR, for more details see
+      `corresponding ECB
+      page <https://www.ecb.europa.eu/stats/policy_and_exchange_rates/euro_reference_exchange_rates/html/index.en.html>`__.
 
 This module is compatible with ``currency_rate_inverted`` module
 provided by OCA, that allows to maintain exchange rates in inverted
@@ -92,38 +92,38 @@ Authors
 Contributors
 ------------
 
-- Nicolas Bessi <nicolas.bessi@camptocamp.com>
-- Jean-Baptiste Aubort <jean-baptiste.aubort@camptocamp.com>
-- Joël Grand-Guillaume <joel.grandguillaume@camptocamp.com>
-- Grzegorz Grzelak <grzegorz.grzelak@openglobe.pl> (ECB, NBP)
-- Vincent Renaville <vincent.renaville@camptocamp.com>
-- Yannick Vaucher <yannick.vaucher@camptocamp.com>
-- Guewen Baconnier <guewen.baconnier@camptocamp.com>
-- Lorenzo Battistini <lorenzo.battistini@agilebg.com> (Port to V7)
-- Agustin Cruz <openpyme.mx> (BdM)
-- Jacque-Etienne Baudoux <je@bcim.be>
-- Juan Jose Scarafia <jjscarafia@paintballrosario.com.ar>
-- Mathieu Benoi <mathben963@gmail.com>
-- Fekete Mihai <feketemihai@gmail.com> (Port to V8)
-- Dorin Hongu <dhongu@gmail.com> (BNR)
-- Paul McDermott
-- Alexis de Lattre <alexis@via.ecp.fr>
-- Miku Laitinen
-- Assem Bayahi
-- Daniel Dico <ddico@oerp.ca> (BOC)
-- Dmytro Katyukha <firemage.dima@gmail.com>
-- Jesús Ventosinos Mayor <jesus@comunitea.com>
-- `CorporateHub <https://corporatehub.eu/>`__
+-  Nicolas Bessi <nicolas.bessi@camptocamp.com>
+-  Jean-Baptiste Aubort <jean-baptiste.aubort@camptocamp.com>
+-  Joël Grand-Guillaume <joel.grandguillaume@camptocamp.com>
+-  Grzegorz Grzelak <grzegorz.grzelak@openglobe.pl> (ECB, NBP)
+-  Vincent Renaville <vincent.renaville@camptocamp.com>
+-  Yannick Vaucher <yannick.vaucher@camptocamp.com>
+-  Guewen Baconnier <guewen.baconnier@camptocamp.com>
+-  Lorenzo Battistini <lorenzo.battistini@agilebg.com> (Port to V7)
+-  Agustin Cruz <openpyme.mx> (BdM)
+-  Jacque-Etienne Baudoux <je@bcim.be>
+-  Juan Jose Scarafia <jjscarafia@paintballrosario.com.ar>
+-  Mathieu Benoi <mathben963@gmail.com>
+-  Fekete Mihai <feketemihai@gmail.com> (Port to V8)
+-  Dorin Hongu <dhongu@gmail.com> (BNR)
+-  Paul McDermott
+-  Alexis de Lattre <alexis@via.ecp.fr>
+-  Miku Laitinen
+-  Assem Bayahi
+-  Daniel Dico <ddico@oerp.ca> (BOC)
+-  Dmytro Katyukha <firemage.dima@gmail.com>
+-  Jesús Ventosinos Mayor <jesus@comunitea.com>
+-  `CorporateHub <https://corporatehub.eu/>`__
 
-  - Alexey Pelykh <alexey.pelykh@corphub.eu>
+   -  Alexey Pelykh <alexey.pelykh@corphub.eu>
 
-- `Quartile Limited <https://www.quartile.co/>`__:
+-  `Quartile Limited <https://www.quartile.co/>`__:
 
-  - Tatsuki Kanda <kanda@quartile.co>
+   -  Tatsuki Kanda <kanda@quartile.co>
 
-- `Komit Company Limited <https://komit-consulting.com/>`__:
+-  `Komit Company Limited <https://komit-consulting.com/>`__:
 
-  - Quoc Pham Ngoc <quoc-pn@komit-consulting.com>
+   -  Quoc Pham Ngoc <quoc-pn@komit-consulting.com>
 
 Maintainers
 -----------

--- a/currency_rate_update/__manifest__.py
+++ b/currency_rate_update/__manifest__.py
@@ -16,10 +16,10 @@
         "data/cron.xml",
         "security/ir.model.access.csv",
         "security/res_currency_rate_provider.xml",
+        "wizards/res_currency_rate_update_wizard.xml",
         "views/res_currency_rate.xml",
         "views/res_currency_rate_provider.xml",
         "views/res_config_settings.xml",
-        "wizards/res_currency_rate_update_wizard.xml",
     ],
     "installable": True,
 }

--- a/currency_rate_update/static/description/index.html
+++ b/currency_rate_update/static/description/index.html
@@ -375,10 +375,10 @@ bundles following built-in providers:</p>
 <blockquote>
 <ul class="simple">
 <li><strong>European Central Bank</strong> (ported by Grzegorz Grzelak -
-OpenGLOBE.pl): reference rates are based on the regular daily query
-procedure between central banks within and outside the European
-System of Central Banks, which normally takes place at 2:15 p.m.
-(14:15) ECB time. Source is in EUR, for more details see
+OpenGLOBE.pl): reference rates are based on the regular daily
+query procedure between central banks within and outside the
+European System of Central Banks, which normally takes place at
+2:15 p.m. (14:15) ECB time. Source is in EUR, for more details see
 <a class="reference external" href="https://www.ecb.europa.eu/stats/policy_and_exchange_rates/euro_reference_exchange_rates/html/index.en.html">corresponding ECB
 page</a>.</li>
 </ul>

--- a/currency_rate_update/views/res_currency_rate_provider.xml
+++ b/currency_rate_update/views/res_currency_rate_provider.xml
@@ -8,7 +8,7 @@
         <field name="name">res.currency.rate.provider.filter</field>
         <field name="model">res.currency.rate.provider</field>
         <field name="arch" type="xml">
-            <search string="Currency Rates Providers">
+            <search>
                 <field name="service" />
                 <field name="company_id" groups="base.group_multi_company" />
                 <filter
@@ -38,7 +38,14 @@
         <field name="name">res.currency.rate.provider.form</field>
         <field name="model">res.currency.rate.provider</field>
         <field name="arch" type="xml">
-            <form string="Currency Rates Provider">
+            <form>
+                <header>
+                    <button
+                        name="%(res_currency_rate_update_wizard_action)d"
+                        type="action"
+                        string="Update Rates Now"
+                    />
+                </header>
                 <sheet>
                     <widget
                         name="web_ribbon"
@@ -96,34 +103,6 @@
                 </sheet>
                 <chatter />
             </form>
-        </field>
-    </record>
-    <record
-        id="action_res_currency_rate_provider_update_wizard"
-        model="ir.actions.server"
-    >
-        <field name="name">Update Rates Wizard</field>
-        <field name="type">ir.actions.server</field>
-        <field
-            name="model_id"
-            ref="currency_rate_update.model_res_currency_rate_provider"
-        />
-        <field
-            name="binding_model_id"
-            ref="currency_rate_update.model_res_currency_rate_provider"
-        />
-        <field name="state">code</field>
-        <field name="code">
-            if records:
-                action = {
-                    'type': 'ir.actions.act_window',
-                    'res_model': 'res.currency.rate.update.wizard',
-                    'views': [[False, 'form']],
-                    'target': 'new',
-                    'context': {
-                        'default_provider_ids': [(6, False, records.ids)],
-                    },
-                }
         </field>
     </record>
     <record model="ir.actions.act_window" id="action_res_currency_rate_provider">

--- a/currency_rate_update/wizards/res_currency_rate_update_wizard.py
+++ b/currency_rate_update/wizards/res_currency_rate_update_wizard.py
@@ -1,7 +1,7 @@
 # Copyright 2019 Brainbean Apps (https://brainbeanapps.com)
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
-from odoo import fields, models
+from odoo import Command, api, fields, models
 
 
 class ResCurrencyRateUpdateWizard(models.TransientModel):
@@ -21,9 +21,15 @@ class ResCurrencyRateUpdateWizard(models.TransientModel):
         column2="provider_id",
     )
 
+    @api.model
+    def default_get(self, fields_list):
+        res = super().default_get(fields_list)
+        if self._context.get(
+            "active_model"
+        ) == "res.currency.rate.provider" and self._context.get("active_ids"):
+            res["provider_ids"] = [Command.set(self._context["active_ids"])]
+        return res
+
     def action_update(self):
         self.ensure_one()
-
         self.provider_ids._update(self.date_from, self.date_to)
-
-        return {"type": "ir.actions.act_window_close"}

--- a/currency_rate_update/wizards/res_currency_rate_update_wizard.xml
+++ b/currency_rate_update/wizards/res_currency_rate_update_wizard.xml
@@ -9,15 +9,10 @@
         <field name="model">res.currency.rate.update.wizard</field>
         <field name="arch" type="xml">
             <form>
-                <group name="filter">
-                    <group name="date_range" colspan="2">
-                        <group>
-                            <field name="date_from" />
-                        </group>
-                        <group>
-                            <field name="date_to" />
-                        </group>
-                    </group>
+                <group name="main">
+                    <field name="provider_ids" widget="many2many_tags" />
+                    <field name="date_from" />
+                    <field name="date_to" />
                 </group>
                 <footer>
                     <button
@@ -31,5 +26,16 @@
                 </footer>
             </form>
         </field>
+    </record>
+    <record id="res_currency_rate_update_wizard_action" model="ir.actions.act_window">
+        <field name="name">Update Currency Rates</field>
+        <field name="res_model">res.currency.rate.update.wizard</field>
+        <field name="view_mode">form</field>
+        <field name="target">new</field>
+        <field
+            name="binding_model_id"
+            ref="currency_rate_update.model_res_currency_rate_provider"
+        />
+        <field name="binding_view_types">list</field>
     </record>
 </odoo>


### PR DESCRIPTION
The button to access the wizard is now directly visible from currency rate provider form view
Modernize the code to launch the wizard: replace ir.actions.server by ir.actions.act_window